### PR TITLE
Fix error logging for automated speedtests

### DIFF
--- a/nb-speedtest/src/components/SingleResult.tsx
+++ b/nb-speedtest/src/components/SingleResult.tsx
@@ -2,6 +2,7 @@ import { Results } from "@cloudflare/speedtest";
 import { TbDownload, TbUpload, TbExclamationCircle } from "solid-icons/tb";
 import { Component, Show, type JSX } from "solid-js";
 import { TestResult } from "../types/test-result";
+import { SpeedtestError } from "../types/speedtest-error";
 import { useTranslation } from "../i18n/context";
 import { formatLatencyDisplay } from "../util/format-latency";
 
@@ -29,7 +30,7 @@ const Stat: Component<{ label?: string, bandwidth: number, latency: number, jitt
   </div>
 }
 
-const ErrorDisplay: Component<{ error: Error }> = (props) => {
+const ErrorDisplay: Component<{ error: SpeedtestError }> = (props) => {
   const { t } = useTranslation();
   return <div class="stats shadow-md my-1 bg-base-200 px-2 overflow-x-hidden max-[25tem]:stats-vertical">
     <div class={`stat text-primary ${statPadding}`}>
@@ -47,7 +48,7 @@ export const SingleResult: Component<{ result?: TestResult }> = (props) => {
   const { t } = useTranslation();
   return <Show
     when={props.result?.success !== false}
-    fallback={<ErrorDisplay error={props.result?.success === false ? props.result.error : new Error(t.speedtest.unknownError())} />}
+    fallback={<ErrorDisplay error={props.result?.success === false ? props.result.error : { message: t.speedtest.unknownError() }} />}
   >
     <div class="stats shadow-md my-1 bg-base-200 px-2 overflow-x-hidden max-[25tem]:stats-vertical">
       <Stat bandwidth={props.result?.success ? props.result.result.getSummary()?.download : 0} latency={props.result?.success ? props.result.result.getSummary()?.downLoadedLatency : undefined} jitter={props.result?.success ? props.result.result.getSummary()?.downLoadedJitter : undefined} icon={<TbDownload />}></Stat>

--- a/nb-speedtest/src/types/speedtest-error.ts
+++ b/nb-speedtest/src/types/speedtest-error.ts
@@ -1,0 +1,3 @@
+export interface SpeedtestError {
+  message: string;
+}

--- a/nb-speedtest/src/types/test-result.ts
+++ b/nb-speedtest/src/types/test-result.ts
@@ -1,8 +1,9 @@
 import { Results } from '@cloudflare/speedtest'
+import { SpeedtestError } from './speedtest-error'
 
 export interface TestResult {
   label: string;
   success: boolean;
   result?: Results;
-  error?: Error;
+  error?: SpeedtestError;
 }

--- a/nb-speedtest/src/util/create-speedtest.ts
+++ b/nb-speedtest/src/util/create-speedtest.ts
@@ -2,10 +2,11 @@ import SpeedTestEngine, { ConfigOptions, Results } from "@cloudflare/speedtest"
 import { createAnimatedSignal } from "./animated-signal"
 import { createSignal, onCleanup, runWithOwner } from "solid-js"
 import { config as appConfig } from "../data/config"
+import { SpeedtestError } from "../types/speedtest-error"
 
 type SpeedTestCallbacks = {
 	onDone?: (results: Results) => void
-	onError?: (error: Error) => void
+	onError?: (error: SpeedtestError) => void
 	timeoutMs?: number
 }
 
@@ -37,7 +38,7 @@ export function createSpeedtest(config: ConfigOptions, callbacks: SpeedTestCallb
 
 		if (isRunning() && !isFinished()) {
 			timeoutId = setTimeout(() => {
-				const error = new Error(`Speedtest timeout after ${timeoutMs}ms`)
+				const error = { message: `Speedtest timeout after ${timeoutMs}ms` }
 				console.error("Speedtest timeout", error)
 				speedTest.pause()
 				if (callbacks.onError) {
@@ -93,7 +94,7 @@ export function createSpeedtest(config: ConfigOptions, callbacks: SpeedTestCallb
 		clearTimeoutTimer()
 		console.error("Speedtest error", error)
 		if (callbacks.onError) {
-			callbacks.onError(new Error(error))
+			callbacks.onError({ message: error })
 		}
 	}
 	onCleanup(() => {


### PR DESCRIPTION
Use error type that is JSON serializable for communication with speedtesttest runner script