### PR TITLE
abort downloads / uploads running more than 60 seconds

### DIFF
--- a/nb-speedtest/src/components/SingleTest.tsx
+++ b/nb-speedtest/src/components/SingleTest.tsx
@@ -23,6 +23,11 @@ export const SingleTest: Component<{
       onDone: (result) => props.onComplete?.({ success: true, result, label: props.label }),
       onError: (error) => {
         console.error(`Speedtest ${props.label} error:`, error)
+        if (error.message && error.message.includes("bandwidthAbortRequestDuration")) {
+            // this error does not mean that the test failed in its entirety
+            // don't set success false
+            return;
+        }
         props.onComplete?.({ success: false, error, label: props.label })
       }
     })

--- a/nb-speedtest/src/data/test-runs.ts
+++ b/nb-speedtest/src/data/test-runs.ts
@@ -29,6 +29,7 @@ export function getTestRuns(sessionID: string, routeLabeler: (letter: string, la
 			turnServerCredsApiUrl: `${d.uri}/__turn`,
 			turnServerUri: "turn.cloudflare.com:3478",
 			includeCredentials: false,
+			bandwidthAbortRequestDuration: 60 * 1000,
 			measurements: [
 				{ type: "download", bytes: 100_000, count: 2 },
 				{ type: "upload", bytes: 100_000, count: 2 },


### PR DESCRIPTION
bandwidthAbortRequestDuration parameter for the cloudflare test allows aborting downloads / uploads to be aborted when they take longer than a certain timeout

using this parameter requires a slight modification in the onError handler as this error doesn't mean that the entire test errors, it is just an error for that particular download / upload

more testing required as i don't fully understand all the interactions of the test harness with the cloudflare speedtest

this helps with routes which rapidly degrade while the measurement sizes are gradually stepped up

it still takes 2 minutes for the test for a route to abort the upload and the download, much better than previously though

see: https://github.com/AKVorrat/Netzbremse.de/issues/18