### PR TITLE
add 1 measurement size to test-runs

### DIFF
--- a/nb-speedtest/src/data/test-runs.ts
+++ b/nb-speedtest/src/data/test-runs.ts
@@ -33,6 +33,8 @@ export function getTestRuns(sessionID: string, routeLabeler: (letter: string, la
 			measurements: [
 				{ type: "download", bytes: 100_000, count: 2 },
 				{ type: "upload", bytes: 100_000, count: 2 },
+				{ type: "download", bytes: 1_000_000, count: 2 },
+				{ type: "upload", bytes: 700_000, count: 2 },
 				{ type: "download", bytes: 10_000_000, count: 2 },
 				{ type: "upload", bytes: 5_000_000, count: 2 },
 				{ type: "download", bytes: 25_000_000, count: 2 },


### PR DESCRIPTION
this helps with long test durations for slow routes.

the cloudflare test will stop trying larger measurements once the duration for the download / upload exceeds 1 second (bandwidthFinishRequestDuration)

on slow routes, 100 KB measurements would take less than 1 second but the test for 10 MB would could take up to 100 seconds assuming the same speed for both measurements

with the added size, factors between consecutive measurements are <= 10 instead of having a factor of 100 between 100 kB and 10 MB before